### PR TITLE
Add menu option to copy full prefixed rule ID.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Note: When using clipboard, the extension is able to handle rule prefixes such a
 
 ### Copy Rule ID
 
-When editing a file (Rule, Ansible, Bash, Anaconda, Puppet) you can right click and activate `Copy Rule ID` to copy the corresponding rule's ID.
+When editing a file (Rule, Ansible, Bash, Anaconda, Puppet) you can right click and activate `Copy Rule ID` to copy the corresponding rule's ID. There is also an option to copy the full prefixed rule ID. You can right click and activate `Copy Full Prefixed Rule ID` to copy the rule's ID prefixed with `xccdf_org.ssgproject.content_rule_`.
 
 ### Auto completion of available rules
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"onCommand:content-navigator.openAnaconda",
 		"onCommand:content-navigator.openPuppet",
 		"onCommand:content-navigator.copyRuleId",
+		"onCommand:content-navigator.copyFullPrefixedRuleId",
 		"*"
 	],
 	"main": "./out/content-navigator.js",
@@ -61,6 +62,10 @@
 			{
 				"command": "content-navigator.copyRuleId",
 				"title": "Copy Rule ID"
+			},
+			{
+				"command": "content-navigator.copyFullPrefixedRuleId",
+				"title": "Copy Full Prefixed Rule ID"
 			}
 		],
 		"menus": {
@@ -85,11 +90,17 @@
 				},
 				{
 					"command": "content-navigator.copyRuleId"
+				},
+				{
+					"command": "content-navigator.copyFullPrefixedRuleId"
 				}
 			],
 			"explorer/context": [
 				{
 					"command": "content-navigator.copyRuleId"
+				},
+				{
+					"command": "content-navigator.copyFullPrefixedRuleId"
 				}
 			]
 		},

--- a/src/content-navigator.ts
+++ b/src/content-navigator.ts
@@ -155,6 +155,16 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 	});
 
+	let copy_full_prefixed_rule_id_command = vscode.commands.registerCommand('content-navigator.copyFullPrefixedRuleId', async (fileUri) => {
+		if(fileUri != null) {
+			let word = getRuleId(fileUri);
+			if (word != "") {
+				vscode.window.showInformationMessage("Rule ID copied to Clipboard: xccdf_org.ssgproject.content_rule_" + word)
+				vscode.env.clipboard.writeText("xccdf_org.ssgproject.content_rule_" + word)
+			}
+		}
+	});
+
 	context.subscriptions.push(open_rule_command);
 	context.subscriptions.push(open_oval_command);
 	context.subscriptions.push(open_bash_command);
@@ -162,6 +172,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(open_anaconda_command);
 	context.subscriptions.push(open_puppet_command);
 	context.subscriptions.push(copy_rule_id_command);
+	context.subscriptions.push(copy_full_prefixed_rule_id_command);
 
 	let completionList: vscode.CompletionItem[] = [];
 


### PR DESCRIPTION
Prefix: "xccdf_org.ssgproject.content_rule_"

Fixes #16 

- [x] Add documentation