### PR TITLE
Compliance As Code Test Suite Launch Configuration Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- Launch configuration template for ComplianceAsCode Test Suite
+- VSCode properties to control the launch configuration for ComplianceAsCode Test Suite
+- Detect rule id when editing a test scenario using the pattern `*.pass.sh` and `*.fail.sh`
+### Fixed
+- Do not print selected/clipboard text when failing to open content.
 
 ## [0.0.9] - 2020-02-12
 ### Added

--- a/README.md
+++ b/README.md
@@ -87,3 +87,13 @@ When editing a Rule file (`rule.yml`), code snippets are available. You can simp
   - template_timer_enabled
 
 More details on templates you can find by activating the respective snippet on VSCode or on [ComplianceAsCode/content Templates Section of Developer Guide](https://github.com/ComplianceAsCode/content/blob/master/docs/manual/developer_guide.adoc#732-list-of-available-templates)
+
+### Test Suite Launch Configuration
+
+Content-Navigator provides a launch configuration template for the [ComplianceAsCode/content](https://github.com/ComplianceAsCode/content/) Test Suite.
+
+When editing a `launch.json` configuration file, you can hit `Ctrl+Space` and select the item `Content Navigator Test Suite Setup`. It will create a launch configuration which can be used to run test scenarios using a Virtual Machine. After creating the launch configuration, you need to set Content Navigator properties, such as Domain Name of the Virtual Machine you are using for testing, remediation type and which product is desired to be tested (it will select the appropriate datastream).
+
+Those configuration items can be updated under VSCode preferences. Go to `File->Preferences->Settings` and search for Content Navigator. Configure the fields with desired information and now you can run desired test scenarios by simply launching the newly created configuration when editing a resource of a rule. If the resource you are editing belongs to a [ComplianceAsCode/content](https://github.com/ComplianceAsCode/content/) rule then it will automatically detect the rule id and run the existent test scenarios for it.
+
+A Virtual Machine is required to use this feature. For more information on how to setup your own testing Virtual Machine, check the official documentation on: [How to prepare a backend for testing](https://github.com/ComplianceAsCode/content/tree/master/tests#how-to-prepare-a-backend-for-testing)

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
 								"rule",
 								"--libvirt",
 								"session",
-								"^\"\\${config:content-navigator.ssgts.domainName}\"",
+								"^\"\\${config:content-navigator.testSuite.domainName}\"",
 								"--datastream",
 								"^\"\\${workspaceFolder}/build/ssg-\\${config:content-navigator.testSuite.productName}-ds.xml\"",
 								"--remediate-using",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"onCommand:content-navigator.openPuppet",
 		"onCommand:content-navigator.copyRuleId",
 		"onCommand:content-navigator.copyFullPrefixedRuleId",
+		"onCommand:content-navigator.getRuleId",
 		"*"
 	],
 	"main": "./out/content-navigator.js",
@@ -36,6 +37,10 @@
 			}
 		],
 		"commands": [
+			{
+				"command": "content-navigator.getRuleId",
+				"title": "Get rule ID"
+			},
 			{
 				"command": "content-navigator.openRule",
 				"title": "Open Rule"
@@ -141,7 +146,77 @@
 				"command": "content-navigator.openPuppet",
 				"key": "ctrl+alt+p"
 			}
-		]
+		],
+		"debuggers": [
+			{
+				"type": "content-navigator",
+				"label": "ComplianceAsCode/content test suite",
+				"languages": [
+					"python"
+				],
+				"configurationSnippets": [
+					{
+						"label": "Content Navigator Test Suite Setup",
+						"description": "A new configuration for setup of ComplianceAsCode/content test suite",
+						"body": {
+							"name" : "ComplianceAsCode/content Test Suite", 
+							"type": "python",
+							"request": "launch",
+							"console": "integratedTerminal",
+							"program": "^\"\\${workspaceFolder}/tests/test_suite.py\"",
+							"args": [
+								"rule",
+								"--libvirt",
+								"session",
+								"^\"\\${config:content-navigator.ssgts.domainName}\"",
+								"--datastream",
+								"^\"\\${workspaceFolder}/build/ssg-\\${config:content-navigator.testSuite.productName}-ds.xml\"",
+								"--remediate-using",
+								"^\"\\${config:content-navigator.testSuite.remediationType}\"",
+								"^\"\\${command:content-navigator.getRuleId}\""
+							]
+						}
+					}
+				]
+			}
+		],
+		"configuration": {
+            "type": "object",
+            "title": "Content Navigator",
+            "properties": {
+                "content-navigator.testSuite.domainName": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Virtual Machine's Domain Name",
+                    "scope": "application"
+                },
+                "content-navigator.testSuite.remediationType": {
+                    "type": "string",
+					"default": "oscap",
+					"enum": [
+						"oscap",
+                        "bash",
+                        "ansible"
+                    ],
+                    "description": "Remediation Type",
+                    "scope": "application"
+				},
+                "content-navigator.testSuite.productName": {
+                    "type": "string",
+					"default": "rhel8",
+					"enum": [
+						"rhel6",
+                        "rhel7",
+						"rhel8",
+						"fedora",
+						"sle12",
+						"sle15"
+                    ],
+                    "description": "Product to be Tested",
+                    "scope": "application"
+				}
+			}
+		}
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"publisher": "ggbecker",
 	"displayName": "content-navigator",
 	"description": "Content-Navigator is a Visual Studio Code extension which helps to navigate and create content for https://github.com/ComplianceAsCode/content/",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"license" : "BSD-3-Clause",
 	"engines": {
 		"vscode": "^1.34.0"
@@ -157,9 +157,9 @@
 				"configurationSnippets": [
 					{
 						"label": "Content Navigator Test Suite Setup",
-						"description": "A new configuration for setup of ComplianceAsCode/content test suite",
+						"description": "A new configuration for setup of ComplianceAsCode/content test suite using VSCode properties",
 						"body": {
-							"name" : "ComplianceAsCode/content Test Suite", 
+							"name" : "ComplianceAsCode/content Test Suite using VSCode properties", 
 							"type": "python",
 							"request": "launch",
 							"console": "integratedTerminal",
@@ -203,14 +203,26 @@
 				},
                 "content-navigator.testSuite.productName": {
                     "type": "string",
-					"default": "rhel8",
+					"default": "fedora",
 					"enum": [
-						"rhel6",
-                        "rhel7",
-						"rhel8",
+						"chromium",
+						"debian8", "debian9", "debian10",
+						"eap6",
+						"example",
 						"fedora",
-						"sle12",
-						"sle15"
+						"firefox",
+						"fuse6",
+						"jre",
+						"macos1015",
+						"ocp3", "ocp4",
+						"ol7", "ol8",
+						"opensuse",
+						"rhel6", "rhel7", "rhel8",
+						"rhosp10", "rhosp13",
+						"rhv4",
+						"sle11", "sle12", "sle15",
+						"ubuntu1404", "ubuntu1604", "ubuntu1804",
+						"wrlinux8", "wrlinux1019"
                     ],
                     "description": "Product to be Tested",
                     "scope": "application"

--- a/src/content-navigator.ts
+++ b/src/content-navigator.ts
@@ -26,6 +26,9 @@ function _getRuleId(uri: vscode.Uri): string
 			uri_str.indexOf('ansible/shared.yml') >= 0 ||
 			uri_str.indexOf('ignition/shared.yml') >= 0 ||
 			uri_str.indexOf('anaconda/shared.anaconda') >= 0 ||
+			uri_str.indexOf('.pass.sh') >= 0 ||
+			uri_str.indexOf('.fail.sh') >= 0 ||
+			uri_str.indexOf('anaconda/shared.anaconda') >= 0 ||
 			uri_str.indexOf('puppet/shared.pp') >= 0){
 		let paths: string[] = uri_str.split("/");
 		return paths[paths.length - 3];
@@ -137,7 +140,7 @@ export async function openContent(location: string) {
 		}
 	}
 
-	vscode.window.showInformationMessage("Could not find any matching file (" + location + ") with: " + rule_id);
+	vscode.window.showInformationMessage("Could not find any matching file with following pattern: " + location + "");
 }
 
 export function activate(context: vscode.ExtensionContext) {

--- a/src/content-navigator.ts
+++ b/src/content-navigator.ts
@@ -2,8 +2,18 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
+export function getRuleId(): string
+{
+	let editor = vscode.window.activeTextEditor;
+	if(editor) {
+		return _getRuleId(editor.document.uri);
+	}
+	else {
+		return "";
+	}
+}
 
-function getRuleId(uri: vscode.Uri): string
+function _getRuleId(uri: vscode.Uri): string
 {
 	let uri_str = uri.toString()
 
@@ -109,7 +119,7 @@ export async function openContent(location: string) {
 		let selection = editor.selection;
 
 		// rule id from current opened file
-		rule_id = getRuleId(document.uri);
+		rule_id = _getRuleId(document.uri);
 		if(rule_id != "")
 		{
 			if(await openFile(rule_id, location)){
@@ -155,7 +165,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	let copy_rule_id_command = vscode.commands.registerCommand('content-navigator.copyRuleId', async (fileUri) => {
 		if(fileUri != null) {
-			let word = getRuleId(fileUri);
+			let word = _getRuleId(fileUri);
 			if (word != "") {
 				vscode.window.showInformationMessage("Rule ID copied to Clipboard: " + word)
 				vscode.env.clipboard.writeText(word)
@@ -163,14 +173,19 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 	});
 
+
 	let copy_full_prefixed_rule_id_command = vscode.commands.registerCommand('content-navigator.copyFullPrefixedRuleId', async (fileUri) => {
 		if(fileUri != null) {
-			let word = getRuleId(fileUri);
+			let word = _getRuleId(fileUri);
 			if (word != "") {
 				vscode.window.showInformationMessage("Rule ID copied to Clipboard: xccdf_org.ssgproject.content_rule_" + word)
 				vscode.env.clipboard.writeText("xccdf_org.ssgproject.content_rule_" + word)
 			}
 		}
+	});
+
+	let get_rule_id = vscode.commands.registerCommand('content-navigator.getRuleId', () => {
+		return getRuleId();
 	});
 
 	context.subscriptions.push(open_rule_command);
@@ -182,6 +197,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(open_puppet_command);
 	context.subscriptions.push(copy_rule_id_command);
 	context.subscriptions.push(copy_full_prefixed_rule_id_command);
+	context.subscriptions.push(get_rule_id);
 
 	let completionList: vscode.CompletionItem[] = [];
 


### PR DESCRIPTION
Add launch configuration template for Compliance As Code Test Suite.

Also adds support for detection of rule id when editing a test scenario.

Fixes: #28, #9 