### PR TITLE
Remove fallback option in Open Built content.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+## [1.0.1] - 2022-07-18
+### Fixed
+- Open Built content: only the fallback (RHEL8) built content was being opened. The fallback option was removed.
 ## [1.0.0] - 2022-07-14
 ### Added
 - Option to open built content files.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"displayName": "Content Navigator",
 	"description": "Content Navigator helps security content authors to create content for https://github.com/ComplianceAsCode/content",
 	"icon": "icon.png",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"license": "BSD-3-Clause",
 	"engines": {
 		"vscode": "^1.59.0"

--- a/src/content-navigator.ts
+++ b/src/content-navigator.ts
@@ -1,6 +1,5 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-import { runInContext } from 'vm';
 import * as vscode from 'vscode';
 
 export function getRuleId(): string
@@ -222,17 +221,11 @@ export async function openVariableFile(built_content: boolean) {
 }
 
 async function openBuiltFile(rule_id : string, location : string) : Promise<boolean> {
-	const config = vscode.workspace.getConfiguration('content-navigator')
 	let uries;
 
-	// product name - defaults to rhel8 if the build/product folder is not found
+	// get product name
+	const config = vscode.workspace.getConfiguration('content-navigator')
 	let product = config.get('testSuite.productName')
-	let uri = vscode.Uri.file("build/"+product);
-	try {
-		await vscode.workspace.fs.stat(uri);
-	} catch {
-		product = "rhel8"
-	}
 
 	if(location == "rule.yml") {
 		uries = await vscode.workspace.findFiles('build/' + product + '/rules/' + rule_id + ".yml");


### PR DESCRIPTION
Only try to open built content from the product that is defined in the
settings.